### PR TITLE
fix(module: datepicker): fix unit test failures

### DIFF
--- a/components/date-picker/date-picker.component.spec.ts
+++ b/components/date-picker/date-picker.component.spec.ts
@@ -51,7 +51,8 @@ describe('DatePickerComponent', () => {
     button.click();
     fixture.detectChanges();
     datePickerEle = document.querySelector('datepicker');
-    expect(datePickerEle.querySelector('.am-picker-col-item').innerText).toBe('2019', 'minDate is 2000');
+    const thisYear = new Date().getFullYear().toString();
+    expect(datePickerEle.querySelector('.am-picker-col-item').innerText).toBe(thisYear, `minDate is ${thisYear}`);
     datePickerEle.querySelector('.am-picker-popup-header-right').click();
   });
 
@@ -61,7 +62,8 @@ describe('DatePickerComponent', () => {
     button.click();
     fixture.detectChanges();
     datePickerEle = document.querySelector('datepicker');
-    expect(datePickerEle.querySelector('.am-picker-col-item').innerText).toBe('2019', 'minDate is 2000');
+    const thisYear = new Date().getFullYear().toString();
+    expect(datePickerEle.querySelector('.am-picker-col-item').innerText).toBe(thisYear, `minDate is ${thisYear}`);
     datePickerEle.querySelector('.am-picker-popup-header-right').click();
   });
 


### PR DESCRIPTION
## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/NG-ZORRO/ng-zorro-antd-mobile/blob/master/CONTRIBUTING.md#commit
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->
```
[ ] Bugfix
[ ] Feature
[ ] Code style update (formatting, local variables)
[x] Refactoring (no functional changes, no api changes)
[ ] Build related changes
[ ] CI related changes
[ ] Documentation content changes
[ ] Application (the showcase website) / infrastructure changes
[ ] Other... Please describe:
```

## What is the current behavior?

在`datepicker`的一个测试用例中, 写死了年份为2019年, 现在是2020年了, 会导致这个单测必定失败.
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Issue Number: N/A


## What is the new behavior?


## Does this PR introduce a breaking change?
```
[ ] Yes
[x] No
```

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information
