### PR TITLE
fix(module: input-item): input cursor always turn to end position

### DIFF
--- a/components/input-item/input-item.component.html
+++ b/components/input-item/input-item.component.html
@@ -23,6 +23,7 @@
     <div *ngIf="type !== 'money'">
       <input
         #inputElement
+        style="outline:none"
         [type]="type"
         [name]="name"
         [(ngModel)]="value"
@@ -39,7 +40,6 @@
         (compositionend)="compositionEnd()"
         (blur)="inputBlur(value)"
         (focus)="inputFocus(value)"
-        style="outline:none"
       />
     </div>
   </div>

--- a/components/input-item/input-item.component.spec.ts
+++ b/components/input-item/input-item.component.spec.ts
@@ -344,23 +344,11 @@ describe('InputComponent', () => {
     tick(0);
     expect(component.inputItemComp.value).toBe('123');
 
-    component.inputItemComp.inputType = 'text';
-    component.inputItemComp.inputChange('sdf12hah3');
-    component.clickTitle();
-    tick(0);
-    expect(component.inputItemComp.value).toBe('sdf12hah3');
-
     component.inputItemComp.inputType = 'password';
-    component.inputItemComp.inputChange('sdf12hah3');
+    component.inputItemComp.inputChange('passwordDemo');
     component.clickTitle();
     tick(0);
-    expect(component.inputItemComp.value).toBe('sdf12hah3');
-
-    component.inputItemComp.inputType = 'test';
-    component.inputItemComp.inputChange('sdf12hah3');
-    component.clickTitle();
-    tick(0);
-    expect(component.inputItemComp.value).toBe('sdf12hah3');
+    expect(component.inputItemComp.value).toBe('passwordDemo');
   }));
   it('should OnChange work, type is money', () => {
     component.type = 'money';

--- a/components/input-item/input-item.component.ts
+++ b/components/input-item/input-item.component.ts
@@ -6,16 +6,15 @@ import {
   EventEmitter,
   ViewChild,
   OnInit,
-  OnChanges,
   HostBinding,
   Renderer2,
   ElementRef,
   forwardRef,
-  TemplateRef,
-  AfterViewChecked
+  TemplateRef
 } from '@angular/core';
 import { ControlValueAccessor, NG_VALUE_ACCESSOR } from '@angular/forms';
 import { isTemplateRef } from '../core/util/check';
+import { NzmInputType } from './input-item.definitions';
 
 @Component({
   selector: 'InputItem, nzm-input-item',
@@ -36,12 +35,12 @@ export class InputItemComponent implements OnInit, AfterViewInit, ControlValueAc
   setFocus: object = {};
   pattern: string = '';
   autoFocus: boolean = false;
-  inputType: string = 'text';
+  inputType: NzmInputType = 'text';
   ngTemplate: boolean = false;
   isTemplateRef = isTemplateRef;
 
   private _el: HTMLElement;
-  private _type: string = 'text';
+  private _type: NzmInputType = 'text';
   private _value: string;
   private _defaultValue: string = '';
   private _placeholder: string = '';
@@ -64,15 +63,15 @@ export class InputItemComponent implements OnInit, AfterViewInit, ControlValueAc
   private _inputLock = false;
 
   @ViewChild('lableContent', { static: true })
-  lableRef;
+  lableRef: ElementRef;
   @ViewChild('inputElement', { static: false })
-  inputElementRef;
+  inputElementRef: ElementRef;
 
   @Input()
-  get type(): string {
+  get type(): NzmInputType {
     return this._type;
   }
-  set type(value: string) {
+  set type(value: NzmInputType) {
     if (value && value.length > 0) {
       this.inputType = value;
       if (value === 'bankCard' || value === 'phone') {
@@ -259,7 +258,7 @@ export class InputItemComponent implements OnInit, AfterViewInit, ControlValueAc
     this._el = element.nativeElement;
   }
 
-  _onChange = (_: any) => {};
+  _onChange = (_: any) => { };
 
   setCls() {
     if (
@@ -280,15 +279,13 @@ export class InputItemComponent implements OnInit, AfterViewInit, ControlValueAc
     this.controlCls = { [`${this.prefixCls}-control`]: true };
   }
 
-  inputChange(e) {
+  inputChange(inputValue: string) {
     setTimeout(() => {
       if (this._inputLock && this.inputType === 'text') {
         return;
       }
-      let value = e;
+      let value = inputValue;
       switch (this.inputType) {
-        case 'text':
-          break;
         case 'bankCard':
           value = value.replace(/\D/g, '').replace(/(....)(?=.)/g, '$1 ');
           break;
@@ -304,13 +301,10 @@ export class InputItemComponent implements OnInit, AfterViewInit, ControlValueAc
         case 'number':
           value = value.replace(/\D/g, '');
           break;
-        case 'password':
-          break;
-        default:
-          this._value = value;
-          break;
       }
-      this._value = value;
+      if (this.inputType !== 'text') {
+        this._value = value;
+      }
       this._onChange(this._value);
       this.onChange.emit(this._value);
     }, 0);
@@ -383,7 +377,7 @@ export class InputItemComponent implements OnInit, AfterViewInit, ControlValueAc
     this._onChange = fn;
   }
 
-  registerOnTouched(fn: any): void {}
+  registerOnTouched(fn: any): void { }
 
   ngOnInit() {
     this.setCls();

--- a/components/input-item/input-item.definitions.ts
+++ b/components/input-item/input-item.definitions.ts
@@ -1,0 +1,4 @@
+// Options type of input in HTML4.0
+type InputType = 'button' | 'checkbox' | 'file' | 'hidden' | 'image' | 'password' | 'radio' | 'reset' | 'submit' | 'text';
+
+export type NzmInputType = InputType | 'bankCard' | 'phone' | 'number' | 'digit' | 'money ' | 'tel' | 'money';


### PR DESCRIPTION
close #637 

## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/NG-ZORRO/ng-zorro-antd-mobile/blob/master/CONTRIBUTING.md#commit
- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->
```
[x] Bugfix
[ ] Feature
[x] Code style update (formatting, local variables)
[x] Refactoring (no functional changes, no api changes)
[ ] Build related changes
[ ] CI related changes
[ ] Documentation content changes
[ ] Application (the showcase website) / infrastructure changes
[ ] Other... Please describe:
```

## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Issue Number: #637 


## What is the new behavior?

en: Under `'text'` type, the cursor position never jump to the right when you modify the value.
cn: 当type为`'text'`时, 修改值时不会再每次都更改光标至最右侧.

## Does this PR introduce a breaking change?
```
[ ] Yes
[x] No
```

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information
