### PR TITLE
feat: add [compositionFilter] to InputItem

### DIFF
--- a/components/input-item/doc/index.en-US.md
+++ b/components/input-item/doc/index.en-US.md
@@ -31,6 +31,7 @@ Properties | Descrition | Type | Default
 | `[updatePlaceholder]` | Whether to replace the placeholder with cleared content | `boolean` | `false` |
 | `[prefixListCls]` | The class name prefix of list | `string` | `'am-list'` |
 | `[moneyKeyboardAlign]` | Text align direction, only `type='money'` support this api | `'left' \| 'right'` | `'right'` |
+| `[compositionFilter]` | When it is `true` , input mode of PinYin, the value never change before finish input, you can search `compositionstart` event to know more | `boolean` | `true` |
 | `[locale]` | International，can override global configuration,  when`type`is`money`，can cunstom the keyboard confirm item's label | `{ confirmLabel }` | - |
 | `(onErrorClick)` | Callback that is called when the error icon is clicked | `EventEmitter<object>` | - |
 | `(onExtraClick)` | Callback that is called when the extra content is clicked | `EventEmitter<object>` | - |

--- a/components/input-item/doc/index.zh-CN.md
+++ b/components/input-item/doc/index.zh-CN.md
@@ -34,6 +34,7 @@ subtitle: 文本输入
 | `[updatePlaceholder]` | 当清除内容时，是否将清除前的内容替换到 placeholder 中 | `boolean` | `false` |
 | `[prefixListCls]` | 列表 className 前缀 | `string` | `'am-list'` |
 | `[moneyKeyboardAlign]` | 文字排版起始方向, 只有 `type='money'` 支持 | `'left' \| 'right'` | `'right'` |
+| `[compositionFilter]` | 当为 `true` 时, 移动端的拼音输入模式下, 在未完成输入前不会变更值, 可以搜下 `compositionstart` 事件以了解更多 | `boolean` | `true` |
 | `[locale]` | 国际化，可覆盖全局的配置, 当`type`为`money`，可以自定义确认按钮的文案 | `{ confirmLabel }` | - |
 | `(onErrorClick)` | 点击报错 icon 触发的回调函数 | `EventEmitter<object>` | - |
 | `(onExtraClick)` | extra 点击事件触发的回调函数 | `EventEmitter<object>` | - |

--- a/components/input-item/input-item.component.ts
+++ b/components/input-item/input-item.component.ts
@@ -232,6 +232,8 @@ export class InputItemComponent implements OnInit, AfterViewInit, ControlValueAc
     this.setCls();
   }
 
+  @Input() compositionFilter = true;
+
   @Output()
   onChange: EventEmitter<any> = new EventEmitter<any>();
   @Output()
@@ -280,8 +282,9 @@ export class InputItemComponent implements OnInit, AfterViewInit, ControlValueAc
   }
 
   inputChange(inputValue: string) {
+    // 'compositionend' is earlier than ngModelChange, Therefore use timer to make ngModelChange runs after 'compositionend' event
     setTimeout(() => {
-      if (this._inputLock && this.inputType === 'text') {
+      if (this.compositionFilter && this._inputLock && this.inputType === 'text') {
         return;
       }
       let value = inputValue;


### PR DESCRIPTION
close #732 

## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/NG-ZORRO/ng-zorro-antd-mobile/blob/master/CONTRIBUTING.md#commit
- [x] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->
```
[ ] Bugfix
[x] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Build related changes
[ ] CI related changes
[x] Documentation content changes
[ ] Application (the showcase website) / infrastructure changes
[ ] Other... Please describe:
```

## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Issue Number: #731 


## What is the new behavior?
当[compositionFilter]为true时, 在移动端输入内容, 如中文等需要预览状态的语言, 在完成输入前是不会触发ngModelChange的, 也就是无法更改值. 
当[compositionFilter]为false时, 即便在预览模式下也会修改值.

## Does this PR introduce a breaking change?
```
[ ] Yes
[x] No
```

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information
