### PR TITLE
docs(module: modal): fix formatting and inconsistent backticks

### DIFF
--- a/components/modal/doc/index.en-US.md
+++ b/components/modal/doc/index.en-US.md
@@ -33,7 +33,6 @@ Properties | Descrition | Type | Default
 
 Properties | Descrition | Type | Default
 -----------|------------|------|--------
-----|-----|------|------
 | `[title]` | Title | `string \| TemplateRef` | - |
 | `[message]` | Message | `string \| TemplateRef` | - |
 | `[actions]` | Button group | `Array<text: string, onPress: Function, style: object>` | - |
@@ -53,7 +52,7 @@ Properties | Descrition | Type | Default
 | `[placeholders]` | placeholders | `string[]` | - |
 | `[platform]` | Set the special style depends on platform, works on web only | `'android' \| 'ios'` | `'ios'`|
 
-call ModalService.prompt(title, message, callbackOrActions, type?, defaultValue?, placeholders?).close()` can close prompt Modal outside anywhere as you wish.
+call `ModalService.prompt(title, message, callbackOrActions, type?, defaultValue?, placeholders?).close()` can close prompt Modal outside anywhere as you wish.
 
 ### ModalService.operation(actions?) ( Support Platform：WEB )
 
@@ -62,8 +61,7 @@ Properties | Descrition | Type | Default
 | `[actions]` | button group | `Array<text: string, onPress: Function, style: object>` | - |
 | `[platform]` | Set the special style depends on platform, works on web only | `'android' \| 'ios'` | `'ios'`|
 
-call ModalService.operation(actions?).close()` can close Operation Modal outside anywhere as you wish.
-
+call `ModalService.operation(actions?).close()` can close Operation Modal outside anywhere as you wish.
 
 ```ts
 constructor(modal: ModalService) {
@@ -76,22 +74,22 @@ constructor(modal: ModalService) {
 
 #### Other Methods/Attributes for ModalService
 
-| Methods/Attributes | Description | Type |
-|----|----|
+Methods/Attributes | Description | Type 
+-------------------|-------------|-----
 | `openModals` | All currently open Modal list | `ModalRef[]` |
-| `afterAllClose` | Callback called after all Modals closed completely | `Observable&lt;void&gt;` |
+| `afterAllClose` | Callback called after all Modals closed completely | `Observable<void>` |
 | `closeAll()` | Close all modals | `Function` |
 
 #### ModalRef
 
 > ModalRef object is used to control dialogs and communicate with inside content
 
-The dialog created by the service method `ModalService.xxx()` will return a `ModalRef` object that is used to manipulate the dialog , This object has the following methods:
+The dialog created by the service method `ModalService.xxx()` will return a `ModalRef` object that is used to manipulate the dialog, This object has the following methods:
 
-| Method | Description |
-|----|----|
-| `afterOpen` | Same as AfterOpen but of type Observable&lt;void&gt; |
-| `afterClose` | Same as AfterClose, but of type Observable&lt;result:any&gt; |
+Method | Description
+-------|------------
+| `afterOpen` | Same as AfterOpen but of type `Observable<void>` |
+| `afterClose` | Same as AfterClose, but of type `Observable<result:any>` |
 | `close(result: any) => void` | Close (hide) the dialog. <i>Note: When used for a dialog created as a service, this method will destroy the dialog directly (as with the destroy method)</i> |
 | `destroy(result: any) => void` | Destroy the dialog. <i>Note: Used only for dialogs created by the service (non-service created dialogs, this method only hides the dialog)</i> |
 | `getContentComponent() => Component` | Gets the Component instance in the contents of the dialog for `Content`. <i> Note: When the dialog is not initialized (`ngOnInit` is not executed), this function will return `undefined`</i> |


### PR DESCRIPTION
## PR Checklist
Please check if your PR fulfills the following requirements:

- [X] The commit message follows our guidelines: https://github.com/NG-ZORRO/ng-zorro-antd-mobile/blob/master/CONTRIBUTING.md#commit
- [ ] Tests for the changes have been added (for bug fixes / features)
- [X] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->
```
[ ] Bugfix
[ ] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Build related changes
[ ] CI related changes
[X] Documentation content changes
[ ] Application (the showcase website) / infrastructure changes
[ ] Other... Please describe:
```

## What is the current behavior?
The markdown documentation for the modal component has a broken table and missing/inconsistent backticks.

Issue Number: N/A


## What is the new behavior?
The markdown has been corrected and unified with the style present in the rest of the document.

## Does this PR introduce a breaking change?
```
[ ] Yes
[X] No
```

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information
