### PR TITLE
fix(module: calendar): fix typo in calendar english day names

### DIFF
--- a/components/calendar/locale/en_US.ts
+++ b/components/calendar/locale/en_US.ts
@@ -10,7 +10,7 @@ export default {
   dateTimeFormat: 'MM/dd/yyyy w hh:mm',
   dateFormat: 'yyyy/MM/dd w',
   noChoose: 'No Choose',
-  week: ['Sun', 'Mon', 'Tue', 'Wed', 'Thu', 'Fir', 'Sat'],
+  week: ['Sun', 'Mon', 'Tue', 'Wed', 'Thu', 'Fri', 'Sat'],
   clear: 'Clear',
   selectTime: 'Select Time',
   selectStartTime: 'Select Start Time',

--- a/components/locale-provider/locale/calendar/en_US.ts
+++ b/components/locale-provider/locale/calendar/en_US.ts
@@ -10,7 +10,7 @@ export default {
   dateTimeFormat: 'MM/dd/yyyy w hh:mm',
   dateFormat: 'yyyy/MM/dd w',
   noChoose: 'No Choose',
-  week: ['Sun', 'Mon', 'Tue', 'Wed', 'Thu', 'Fir', 'Sat'],
+  week: ['Sun', 'Mon', 'Tue', 'Wed', 'Thu', 'Fri', 'Sat'],
   clear: 'Clear',
   selectTime: 'Select Time',
   selectStartTime: 'Select Start Time',


### PR DESCRIPTION
## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/NG-ZORRO/ng-zorro-antd-mobile/blob/master/CONTRIBUTING.md#commit
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->
```
[x] Bugfix
[ ] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Build related changes
[ ] CI related changes
[ ] Documentation content changes
[ ] Application (the showcase website) / infrastructure changes
[ ] Other... Please describe:
```

## What is the current behavior?

Issue Number: #880 

## What is the new behavior?
The typo is fixed from "Fir" to "Fri".

## Does this PR introduce a breaking change?
```
[ ] Yes
[x] No
```

## Other information
fixes #880 