### PR TITLE
fix(module: textarea-item) fix ngModel

### DIFF
--- a/components/textarea-item/textarea-item.component.ts
+++ b/components/textarea-item/textarea-item.component.ts
@@ -70,7 +70,6 @@ export class TextareaItemComponent implements OnInit, AfterContentChecked, Contr
       this._value = v;
     }
     this.textRef.nativeElement.value = this._value;
-    this._onChange(this._value);
   }
   @Input()
   get defaultValue(): string {


### PR DESCRIPTION
## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/NG-ZORRO/ng-zorro-antd-mobile/blob/master/CONTRIBUTING.md#commit
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->
```
[x] Bugfix
[ ] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Build related changes
[ ] CI related changes
[ ] Documentation content changes
[ ] Application (the showcase website) / infrastructure changes
[ ] Other... Please describe:
```

## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Issue Number: N/A

When a textarea is entered with a value, this._onChange is triggered in both of the following places, which causes the value of the form control to be triggered twice, leading to a number of problems
<img width="449" alt="image" src="https://github.com/NG-ZORRO/ng-zorro-antd-mobile/assets/97489956/b10fc8ec-f21a-40bd-8337-613711b6e2bb">

<img width="456" alt="image" src="https://github.com/NG-ZORRO/ng-zorro-antd-mobile/assets/97489956/4f4df524-4be5-4db1-a068-291c4b88a39f">

## What is the new behavior?


## Does this PR introduce a breaking change?
```
[ ] Yes
[x] No
```

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information
